### PR TITLE
Add codex MkDocs preview pipeline

### DIFF
--- a/.github/workflows/site_codex.yml
+++ b/.github/workflows/site_codex.yml
@@ -1,0 +1,81 @@
+name: Build & Publish Site (codex)
+
+on:
+  push:
+    branches: [ codex ]
+    paths:
+      - 'interface/**'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'tools/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare directories
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path docs/interface/latest | Out-Null
+          New-Item -ItemType Directory -Force -Path docs/interface/latest/images | Out-Null
+
+      - name: Copy LUA/XML/CSV from repo interface/
+        shell: pwsh
+        run: |
+          robocopy interface docs\interface\latest\lua  *.lua /S
+          robocopy interface docs\interface\latest\xml  *.xml /S
+          robocopy interface docs\interface\latest\csv  *.csv /S
+          exit 0
+
+      - name: Install DirectXTex (texconv) for DDS conversion
+        shell: pwsh
+        run: choco install directxtex -y
+
+      - name: Convert DDS -> PNG
+        shell: pwsh
+        run: |
+          $root = Resolve-Path interface
+          $dds = Get-ChildItem -Path $root -Recurse -Include *.dds
+          # Optional: cap conversions to avoid long builds (set to 0 for unlimited)
+          $MAX = 0
+          $count = 0
+          foreach ($f in $dds) {
+            if ($MAX -gt 0 -and $count -ge $MAX) { break }
+            $rel = $f.DirectoryName.Substring($root.Path.Length).TrimStart('\\','/')
+            $outDir = Join-Path "docs/interface/latest/images" $rel
+            New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+            & "C:\Program Files\Microsoft DirectXTex\texconv.exe" -ft png -o $outDir $f.FullName
+            $count++
+          }
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs & plugins
+        run: pip install mkdocs mkdocs-material mkdocs-table-reader-plugin
+
+      - name: Generate interface index
+        run: python tools/make_interface_index.py
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Deploy to GitHub Pages (gh-pages branch)
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          # Tie deployment to the codex branch commits (safe to preview before merge)
+          full_commit_message: "Deploy preview from codex: ${{ github.sha }}"
+          commit_message: "Deploy preview from codex: ${{ github.sha }}"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# RoR Interface & Addon Docs
+
+This site previews the extracted `interface/` contents with code and texture previews.
+
+- **Interface Browser → Latest** shows `.lua`, `.xml`, `.csv`, and converted textures from `.dds`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,15 @@
+site_name: RoR Interface & Addon Docs
+site_url: https://<your-user>.github.io/RoR-Interface
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - content.code.copy
+plugins:
+  - search
+  - table-reader
+nav:
+  - Home: index.md
+  - Interface Browser:
+      - Latest: interface/latest/index.md
+repo_url: https://github.com/xyeppp/RoR-Interface

--- a/tools/make_interface_index.py
+++ b/tools/make_interface_index.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+ROOT = Path("docs/interface/latest")
+ROOT.mkdir(parents=True, exist_ok=True)
+
+def section_header(title):
+    return f"\n## {title}\n"
+
+lines = [
+    "# Interface Browser (Latest)\n",
+    "Auto-generated from the repository's `interface/` folder on branch **codex**.\n"
+]
+
+# Images (converted DDS -> PNG)
+images = sorted(ROOT.glob("images/**/*.png"))
+if images:
+    lines.append(section_header("Textures (converted from DDS)"))
+    # Limit previews to keep page light; link the rest
+    for img in images[:400]:
+        rel = img.relative_to(ROOT).as_posix()
+        lines.append(f"![{rel}]({rel})\n")
+    if len(images) > 400:
+        lines.append(f"\n_+{len(images)-400} more images not inlined; browse the folders above._\n")
+
+def embed_code(label, pattern, fence):
+    files = sorted(ROOT.glob(pattern))
+    if not files:
+        return
+    lines.append(section_header(label))
+    for f in files[:200]:
+        rel = f.relative_to(ROOT).as_posix()
+        try:
+            text = f.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            text = ""
+        if len(text) > 8000:
+            text = text[:8000] + "\n... (truncated) ..."
+        lines.append(f"### {rel}\n```{fence}\n{text}\n```\n")
+    if len(files) > 200:
+        lines.append(f"_+{len(files)-200} more files; browse the folders above._\n")
+
+embed_code("Lua", "lua/**/*.lua", "lua")
+embed_code("XML", "xml/**/*.xml", "xml")
+
+# CSV (link list + one inline preview)
+csvs = sorted(ROOT.glob("csv/**/*.csv"))
+if csvs:
+    lines.append(section_header("CSV"))
+    for f in csvs:
+        rel = f.relative_to(ROOT).as_posix()
+        lines.append(f"- [{rel}]({rel})\n")
+    first = csvs[0].relative_to(ROOT).as_posix()
+    lines.append("\n### Inline preview (first CSV)\n")
+    lines.append(f"{{{{ read_csv('interface/latest/{first}') }}}}\n")
+
+(Path(ROOT) / "index.md").write_text("".join(lines), encoding="utf-8")
+print("Wrote docs/interface/latest/index.md")


### PR DESCRIPTION
## Summary
- add MkDocs Material configuration and docs skeleton for the interface preview site
- script auto-generates the interface browser page from repository assets
- workflow builds the site on codex pushes and publishes previews to gh-pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da5e4c4548832c9a1752387bd3fde3