### PR TITLE
Handle non-UTF8 interface data during MkDocs builds

### DIFF
--- a/.github/workflows/site_codex.yml
+++ b/.github/workflows/site_codex.yml
@@ -1,0 +1,44 @@
+name: Build & Publish Site (codex)
+
+on:
+  push:
+    branches: [codex]
+    paths:
+      - 'interface/**'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'tools/**'
+      - 'requirements.txt'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Deploy to GitHub Pages (gh-pages branch)
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          commit_message: "Deploy preview from codex: ${{ github.sha }}"
+          full_commit_message: "Deploy preview from codex: ${{ github.sha }}"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# RoR Interface & Addon Docs
+
+Welcome to the preview documentation site for the interface assets that ship with this repository.
+The navigation links on the left are generated automatically from the files inside the `interface/`
+directory every time MkDocs builds the site. Use the **Interface Browser → Latest overview** entry to
+explore Lua scripts, XML layouts, CSV tables, and converted textures.
+
+!!! tip
+    When you push updates to the `codex` branch the preview workflow rebuilds the docs and publishes
+    them to GitHub Pages. That lets you review the MkDocs site before merging any changes into `main`.

--- a/docs/interface/latest/.gitignore
+++ b/docs/interface/latest/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore

--- a/functions/globals/Globals2.lua
+++ b/functions/globals/Globals2.lua
@@ -1,4 +1,4 @@
----
+------@meta
 -- @desc Gets the name of ability/macro/item on the hotbar slot.
 -- @param slotId number The slot ID of the hotbar.
 -- @return string The name of ability/macro/item on the hotbar slot.

--- a/functions/globals/Globals3.lua
+++ b/functions/globals/Globals3.lua
@@ -1,4 +1,4 @@
----
+------@meta
 -- @desc Refunds all spent Renown points.
 function RefundRenownPoints()   end
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,34 @@
+site_name: RoR Interface & Addon Docs
+site_url: https://xyeppp.github.io/RoR-Interface
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - content.code.copy
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - md_in_html
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - tables
+  - toc:
+      permalink: true
+plugins:
+  - search
+  - mkdocs-simple-hooks:
+      hooks:
+        on_pre_build: "tools.interface_index:generate_docs"
+nav:
+  - Home: index.md
+  - Interface Browser:
+      - Latest overview: interface/latest/index.md
+repo_url: https://github.com/xyeppp/RoR-Interface
+extra:
+  interface_index:
+    interface_dir: interface
+    output_subdir: interface/latest
+    max_code_entries: 200
+    max_image_entries: 300
+    truncate_bytes: 8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs==1.6.0
+mkdocs-material==9.5.34
+mkdocs-simple-hooks==0.1.5
+pillow==11.3.0

--- a/tools/interface_index.py
+++ b/tools/interface_index.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Dict, List
+
+try:  # pragma: no cover - optional dependency
+    from PIL import Image
+    import pillow_dds  # noqa: F401  # pylint: disable=unused-import
+except Exception:  # pragma: no cover - optional dependency
+    Image = None  # type: ignore
+
+CODE_EXTENSIONS = {".lua": "lua", ".xml": "xml"}
+
+
+def _project_dir(config: Dict) -> Path:
+    config_path = config.get("config_file_path")
+    if config_path:
+        return Path(config_path).resolve().parent
+    return Path.cwd()
+
+
+def _docs_dir(project_dir: Path, config: Dict) -> Path:
+    docs_dir = Path(config.get("docs_dir", "docs"))
+    if not docs_dir.is_absolute():
+        docs_dir = project_dir / docs_dir
+    return docs_dir.resolve()
+
+
+def _load_settings(config: Dict) -> Dict:
+    extra = config.get("extra") or {}
+    return extra.get("interface_index", {})
+
+
+def _ensure_gitignore(target: Path) -> None:
+    gitignore = target / ".gitignore"
+    gitignore.write_text("*\n!/.gitignore\n", encoding="utf-8")
+
+
+def _read_text_with_fallback(path: Path) -> str:
+    data = path.read_bytes()
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode("latin-1", errors="ignore")
+
+
+def _truncate_text(content: str, limit: int) -> str:
+    if limit <= 0:
+        return content
+    encoded = content.encode("utf-8", errors="ignore")
+    if len(encoded) <= limit:
+        return content
+    truncated = encoded[:limit]
+    safe = truncated.decode("utf-8", errors="ignore")
+    return safe + "\n... (truncated for preview) ..."
+
+
+def _code_page_content(rel_path: str, language: str, truncated_source: str) -> str:
+    lines = [
+        f"# {rel_path}\n",
+        "\n",
+        f"*Source path*: `interface/{rel_path}`\n",
+        "\n",
+        "[Download original](source." + language + ")\n",
+        "\n",
+        f"```{language}\n",
+        truncated_source,
+        "\n```\n",
+    ]
+    return "".join(lines)
+
+
+def _csv_page_content(rel_path: str, preview_text: str) -> str:
+    lines = [
+        f"# {rel_path}\n",
+        "\n",
+        f"*Source path*: `interface/{rel_path}`\n",
+        "\n",
+        "[Download CSV](data.csv)\n",
+        "\n",
+    ]
+
+    if preview_text.strip():
+        lines.extend(["```csv\n", preview_text, "\n```\n"])
+    else:
+        lines.append(
+            "_Preview unavailable: this file could not be decoded as UTF-8 or Latin-1 text._\n"
+        )
+
+    return "".join(lines)
+
+
+def _build_index(entries: Dict[str, List[Dict]], settings: Dict, image_conversion: bool) -> str:
+    max_code_entries = int(settings.get("max_code_entries", 200))
+    max_image_entries = int(settings.get("max_image_entries", 300))
+
+    lines: List[str] = [
+        "# Interface Browser (Latest)\n",
+        "\n",
+        "This page is generated from the repository's `interface/` folder during the MkDocs build.\n",
+        "Use the links below to browse the available previews.\n",
+    ]
+
+    for label, key in (("Lua scripts", "lua"), ("XML layouts", "xml")):
+        if entries[key]:
+            lines.append(f"\n## {label}\n\n")
+            limit = max_code_entries
+            for item in entries[key][:limit]:
+                lines.append(f"- [{item['title']}]({item['link']})\n")
+            remaining = len(entries[key]) - limit
+            if remaining > 0:
+                lines.append(
+                    f"\n_+{remaining} additional files not listed here. Browse the folders for more._\n"
+                )
+
+    if entries["csv"]:
+        lines.append("\n## CSV tables\n\n")
+        for item in entries["csv"]:
+            lines.append(f"- [{item['title']}]({item['link']})\n")
+
+    if not image_conversion:
+        lines.append(
+            "\n!!! warning \"DDS previews unavailable\"\n"
+            "    pillow-dds is not installed, so DDS textures are not converted during the build.\n"
+        )
+    elif entries["images"]:
+        lines.append("\n## Textures (DDS → PNG)\n\n")
+        limit = max_image_entries
+        for item in entries["images"][:limit]:
+            lines.append(f"![{item['title']}]({item['link']})\n")
+        remaining = len(entries["images"]) - limit
+        if remaining > 0:
+            lines.append(
+                f"\n_+{remaining} additional textures converted. Browse the image folders for the rest._\n"
+            )
+
+    return "".join(lines)
+
+
+def generate_docs(config: Dict) -> None:
+    """Hook entry point for mkdocs-simple-hooks."""
+
+    settings = _load_settings(config)
+    project_dir = _project_dir(config)
+    docs_dir = _docs_dir(project_dir, config)
+
+    interface_dir = project_dir / settings.get("interface_dir", "interface")
+    output_subdir = settings.get("output_subdir", "interface/latest")
+    output_dir = docs_dir / output_subdir
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Clean previously generated content but preserve .gitignore if present
+    for path in output_dir.iterdir():
+        if path.name == ".gitignore":
+            continue
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+    entries: Dict[str, List[Dict]] = {"lua": [], "xml": [], "csv": [], "images": []}
+
+    truncate_bytes = int(settings.get("truncate_bytes", 8000))
+    image_conversion_enabled = Image is not None
+
+    if not interface_dir.exists():
+        index_path = output_dir / "index.md"
+        index_path.write_text(
+            "# Interface Browser (Latest)\n\nNo interface assets were found in this repository.\n",
+            encoding="utf-8",
+        )
+        _ensure_gitignore(output_dir)
+        return
+
+    for source_path in sorted(interface_dir.rglob("*")):
+        if not source_path.is_file():
+            continue
+        suffix = source_path.suffix.lower()
+        rel = source_path.relative_to(interface_dir)
+        rel_str = rel.as_posix()
+
+        if suffix in CODE_EXTENSIONS:
+            language = CODE_EXTENSIONS[suffix]
+            page_dir = output_dir / language / rel.parent / source_path.stem
+            page_dir.mkdir(parents=True, exist_ok=True)
+
+            destination_source = page_dir / f"source.{language}"
+            destination_source.write_bytes(source_path.read_bytes())
+
+            text_content = _read_text_with_fallback(source_path)
+            preview = _truncate_text(text_content, truncate_bytes)
+            page_md = _code_page_content(rel_str, language, preview)
+            (page_dir / "index.md").write_text(page_md, encoding="utf-8")
+
+            link_path = (page_dir / "index.md").relative_to(output_dir).as_posix()
+            entries[language].append({"title": rel_str, "link": link_path})
+
+        elif suffix == ".csv":
+            page_dir = output_dir / "csv" / rel.parent / source_path.stem
+            page_dir.mkdir(parents=True, exist_ok=True)
+
+            data_file = page_dir / "data.csv"
+            data_file.write_bytes(source_path.read_bytes())
+
+            csv_text = _read_text_with_fallback(source_path)
+            preview = _truncate_text(csv_text, truncate_bytes)
+            page_md = _csv_page_content(rel_str, preview)
+            (page_dir / "index.md").write_text(page_md, encoding="utf-8")
+
+            link_path = (page_dir / "index.md").relative_to(output_dir).as_posix()
+            entries["csv"].append({"title": rel_str, "link": link_path})
+
+        elif suffix == ".dds" and image_conversion_enabled:
+            image_rel = rel.with_suffix(".png").as_posix()
+            destination = output_dir / "images" / rel.with_suffix(".png")
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                with Image.open(source_path) as img:  # type: ignore
+                    img.save(destination, format="PNG")
+            except Exception as exc:  # pragma: no cover - log error for visibility
+                print(f"[interface-index] Failed to convert {rel_str}: {exc}")
+                continue
+
+            entries["images"].append({"title": rel_str, "link": (destination.relative_to(output_dir).as_posix())})
+
+    for key in entries:
+        entries[key].sort(key=lambda item: item["title"].lower())
+
+    index_content = _build_index(entries, settings, image_conversion_enabled)
+    (output_dir / "index.md").write_text(index_content, encoding="utf-8")
+
+    _ensure_gitignore(output_dir)
+
+    total_pages = sum(len(entries[key]) for key in ("lua", "xml", "csv"))
+    print(
+        "[interface-index] Generated"
+        f" {total_pages} pages and {len(entries['images'])} image previews in {output_dir}"
+    )


### PR DESCRIPTION
## Summary
- update the MkDocs configuration and dependency pins to remove the table-reader plugin that required unavailable packages
- teach the interface index generator to decode Lua, XML, and CSV files with a fallback, replace the CSV table plugin with inline code previews, and generate stable relative links

## Testing
- mkdocs build --strict

------
https://chatgpt.com/codex/tasks/task_b_68da5e4c4548832c9a1752387bd3fde3